### PR TITLE
OG画像のデフォルト設置を nuxt.config.js から移動する

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -3,9 +3,6 @@ const baseDesc =
   process.env.BASE_DISC ||
   'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。'
 const baseUrl = process.env.BASE_URL || 'https://yamanaoku.net/archive'
-const baseOgp =
-  process.env.BASE_OGP || 'https://yamanoku.net/ogp/ogp-archive@2x.png'
-const baseOgpAlt = baseName
 
 const rehypePlugins = [
   'rehype-plugin-auto-resolve-layout-shift',
@@ -26,8 +23,6 @@ export default {
     baseName,
     baseDesc,
     baseUrl,
-    baseOgp,
-    baseOgpAlt,
   },
   head: {
     title: 'アーカイブ',
@@ -42,18 +37,10 @@ export default {
         name: 'description',
         content: baseDesc,
       },
-      {
-        hid: 'og:image',
-        name: 'og:image',
-        content: baseOgp,
-      },
       { name: 'og:title', content: baseName },
       { name: 'og:description', content: baseDesc },
-      { name: 'og:image', content: baseOgp },
-      { name: 'og:image:alt', content: baseOgpAlt },
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:site', content: '@yamanoku' },
-      { name: 'twitter:image:alt', content: baseOgpAlt },
     ],
     link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
   },

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,9 +1,3 @@
-const baseName = process.env.BASE_NAME || 'アーカイブ'
-const baseDesc =
-  process.env.BASE_DISC ||
-  'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。'
-const baseUrl = process.env.BASE_URL || 'https://yamanaoku.net/archive'
-
 const rehypePlugins = [
   'rehype-plugin-auto-resolve-layout-shift',
   'rehype-plugin-image-native-lazy-loading',
@@ -19,11 +13,6 @@ if (process.env.NODE_ENV === 'production') {
 export default {
   target: 'static',
   telemetry: false,
-  env: {
-    baseName,
-    baseDesc,
-    baseUrl,
-  },
   head: {
     title: 'アーカイブ',
     htmlAttrs: {
@@ -32,13 +21,6 @@ export default {
     meta: [
       { charset: 'utf-8' },
       { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-      {
-        hid: 'description',
-        name: 'description',
-        content: baseDesc,
-      },
-      { name: 'og:title', content: baseName },
-      { name: 'og:description', content: baseDesc },
       { name: 'twitter:card', content: 'summary_large_image' },
       { name: 'twitter:site', content: '@yamanoku' },
     ],

--- a/pages/_slug.vue
+++ b/pages/_slug.vue
@@ -95,11 +95,6 @@ export default {
           content: `${this.page.title}`,
         },
         {
-          hid: 'twitter:card',
-          name: 'twitter:card',
-          content: 'summary_large_image',
-        },
-        {
           hid: 'twitter:title',
           name: 'twitter:title',
           content: `${this.page.title}`,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -40,7 +40,7 @@ export default {
   },
   head() {
     return {
-      title: `${this.page.title}`,
+      title: 'アーカイブ',
       meta: [
         {
           hid: 'og:image',
@@ -50,7 +50,7 @@ export default {
         {
           hid: 'og:image:alt',
           property: 'og:image:alt',
-          content: `${this.page.title}`,
+          content: 'Archive Document',
         },
         {
           hid: 'twitter:image',
@@ -60,7 +60,7 @@ export default {
         {
           hid: 'twitter:image:alt',
           property: 'twitter:image:alt',
-          content: `${this.page.title}`,
+          content: 'Archive Document',
         },
       ],
     }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -43,6 +43,21 @@ export default {
       title: 'アーカイブ',
       meta: [
         {
+          hid: 'description',
+          name: 'description',
+          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
+        },
+        {
+          hid: 'og:title',
+          property: 'og:title',
+          content: 'アーカイブ',
+        },
+        {
+          hid: 'og:description',
+          property: 'og:description',
+          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
+        },
+        {
           hid: 'og:image',
           property: 'og:image',
           content: 'https://yamanoku.net/ogp/ogp-archive@2x.png',
@@ -51,6 +66,16 @@ export default {
           hid: 'og:image:alt',
           property: 'og:image:alt',
           content: 'Archive Document',
+        },
+        {
+          hid: 'twitter:title',
+          name: 'twitter:title',
+          content: 'アーカイブ',
+        },
+        {
+          hid: 'twitter:description',
+          name: 'twitter:description',
+          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
         },
         {
           hid: 'twitter:image',

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -38,6 +38,33 @@ export default {
       articles,
     }
   },
+  head() {
+    return {
+      title: `${this.page.title}`,
+      meta: [
+        {
+          hid: 'og:image',
+          property: 'og:image',
+          content: 'https://yamanoku.net/ogp/ogp-archive@2x.png',
+        },
+        {
+          hid: 'og:image:alt',
+          property: 'og:image:alt',
+          content: `${this.page.title}`,
+        },
+        {
+          hid: 'twitter:image',
+          property: 'twitter:image',
+          content: 'https://yamanoku.net/ogp/ogp-archive@2x.png',
+        },
+        {
+          hid: 'twitter:image:alt',
+          property: 'twitter:image:alt',
+          content: `${this.page.title}`,
+        },
+      ],
+    }
+  },
   methods: {
     dateTime(time) {
       return dayjs(time).format('YYYY-MM-DD')

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -45,7 +45,8 @@ export default {
         {
           hid: 'description',
           name: 'description',
-          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
+          content:
+            'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
         },
         {
           hid: 'og:title',
@@ -55,7 +56,8 @@ export default {
         {
           hid: 'og:description',
           property: 'og:description',
-          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
+          content:
+            'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
         },
         {
           hid: 'og:image',
@@ -75,7 +77,8 @@ export default {
         {
           hid: 'twitter:description',
           name: 'twitter:description',
-          content: 'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
+          content:
+            'このページはyamanokuこと大山奥人が書いてきた過去の記事やログを収集したページです。',
         },
         {
           hid: 'twitter:image',


### PR DESCRIPTION
nuxt.config.js 側でベース設定される `<meta data-n-head="ssr" name="og:image" content="https://yamanoku.net/ogp/ogp-archive@2x.png">` が優先されているため、Slack上での展開で影響をうける

<img width="760" alt="Screen Shot 2022-01-16 at 16 54 05" src="https://user-images.githubusercontent.com/1996642/149651903-d07a378a-058f-4e69-89c7-e1b6b43e79ca.png">
