### PR TITLE
`<article>` -> `<ul>` `<li>` 

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,19 +31,19 @@ const posts = (await getCollection('archives')).sort(
       <p>
         移行時にリンク切れなど修正しましたが、内容自体は特にアップデートしておりませんので参照する際はその点ご注意ください。
       </p>
+      <ul>
       {
         posts.map((post) => (
-          <article>
+          <li>
             <time datetime={dayjs(post.data.date).format('YYYY-MM-DD')}>
               {dayjs(post.data.date).format('YYYY-MM-DD')}
             </time>
-            <h2>
-              <a href={post.slug} set:html={parser.translateHTMLString(post.data.title)} />
-            </h2>
-            <p>{post.data.description}</p>
-          </article>
+            -
+            <a href={post.slug} set:html={parser.translateHTMLString(post.data.title)} />
+          </li>
         ))
       }
+      </ul>
     </main>
     <Footer />
   </body>


### PR DESCRIPTION
`<article>` 一覧である必要性を見直す

<table>
<tr>
 <th>現状の形
 <th>ul リストにした場合
<tr>
 <td><img width="1391" alt="Screenshot 2023-08-07 at 15 23 25" src="https://github.com/yamanoku/archives/assets/1996642/d04293e2-3aa9-4d11-9f5d-574ab372d2ef">
 <td><img width="1388" alt="Screenshot 2023-08-07 at 15 23 05" src="https://github.com/yamanoku/archives/assets/1996642/5474e4ac-6c45-4c7d-a1aa-83f497a6c2b2">
</table>

